### PR TITLE
Fix : "Call to undefined method stdClass::routeNotificationFor()" 수정

### DIFF
--- a/src/SensAlimtalkChannel.php
+++ b/src/SensAlimtalkChannel.php
@@ -39,10 +39,8 @@ class SensAlimtalkChannel
          */
         $message = $notification->toSensAlimtalk($notifiable);
 
-        if (! collect($notifiable)->isEmpty()) {
-            if (! $message->to) {
-                $message->to($notifiable->routeNotificationFor('sens_alimtalk', $notification));
-            }
+        if (collect($notifiable)->isNotEmpty() && collect($message->to)->isEmpty()) {
+            $message->to($notifiable->routeNotificationFor('sens_alimtalk', $notification));
         }
 
         try {

--- a/src/SensAlimtalkChannel.php
+++ b/src/SensAlimtalkChannel.php
@@ -39,8 +39,10 @@ class SensAlimtalkChannel
          */
         $message = $notification->toSensAlimtalk($notifiable);
 
-        if (!$message->to) {
-            $message->to($notifiable->routeNotificationFor('sens_alimtalk', $notification));
+        if (! collect($notifiable)->isEmpty()) {
+            if (! $message->to) {
+                $message->to($notifiable->routeNotificationFor('sens_alimtalk', $notification));
+            }
         }
 
         try {


### PR DESCRIPTION
# 문제점
- "$notifiable"를 빈 값으로 보내는데 전화번호가 없는 경우가 종종 있음.
- 이러한 문제로 인해 "Call to undefined method stdClass::routeNotificationFor()" 에러가 발생함.

# 변경점
- "$notifiable"을 검증하는 if문 추가