### PR TITLE
Fix deprecated in php8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "illuminate/notifications": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0"
+        "illuminate/notifications": "~6.0 || ~7.0 || ~8.0 || ~9.0 || ~10.0",
+        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0 || ~10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0 || ^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=7.2",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "illuminate/notifications": "~6.0 || ~7.0 || ~8.0 || ~9.0",
         "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0"

--- a/src/SensAlimtalk.php
+++ b/src/SensAlimtalk.php
@@ -42,8 +42,8 @@ class SensAlimtalk
         $buffer[] = strtoupper($this->method) . ' ' . $this->targetURL;
         $buffer[] = $this->timestamp;
         $buffer[] = $this->accessKey;
-        $secretKey = utf8_encode($this->secretKey);
-        $message = utf8_encode(implode("\n", $buffer));
+        $secretKey = mb_convert_encoding($this->secretKey, 'UTF-8', mb_list_encodings());
+        $message = mb_convert_encoding(implode("\n", $buffer), 'UTF-8', mb_list_encodings());
         $hash = hex2bin(hash_hmac('sha256', $message, $secretKey));
 
         return base64_encode($hash);

--- a/src/SensAlimtalkMessage.php
+++ b/src/SensAlimtalkMessage.php
@@ -18,6 +18,7 @@ class SensAlimtalkMessage
     public $variables;
     public $utmSource;
     public $custom_pattern = '/#{\w.+}/';
+    public $messages = [];
 
     /**
      * SensAlimtalkMessage constructor.
@@ -26,7 +27,6 @@ class SensAlimtalkMessage
     {
         $this->plusFriendId = config('sens-alimtalk.plus_friend_id');
         $this->countryCode = '+82';
-        $this->messages = [];
     }
 
     /**


### PR DESCRIPTION
- Dynamic Properties (https://php.watch/versions/8.2/dynamic-properties-deprecated)
- utf8_encode (https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated)