### PR TITLE
move make timestamp algorithm

### DIFF
--- a/src/SensAlimtalk.php
+++ b/src/SensAlimtalk.php
@@ -5,6 +5,7 @@ namespace Comento\SensAlimtalk;
 
 
 use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
 
 class SensAlimtalk
 {
@@ -13,7 +14,7 @@ class SensAlimtalk
     private $baseURL;
     private $targetURL;
     private $method = 'POST';
-    private $timestamp;
+    private $timestamp = '';
 
     /**
      * SensAlimtalk constructor.
@@ -25,7 +26,6 @@ class SensAlimtalk
     public function __construct($accessKey, $secretKey, $serviceId)
     {
         $this->baseURL = 'https://sens.apigw.ntruss.com';
-        $this->timestamp = (string)(int)round(microtime(true) * 1000);
         $this->accessKey = $accessKey;
         $this->secretKey = $secretKey;
         $this->targetURL = '/alimtalk/v2/services/' . $serviceId . '/messages';
@@ -64,11 +64,13 @@ class SensAlimtalk
 
     /**
      * @param $body
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return ResponseInterface
      */
     public function send($body)
     {
         $client = $this->setClient();
+
+        $this->timestamp = (string)(int)round(microtime(true) * 1000);
 
         return $client->request(
             $this->method,


### PR DESCRIPTION
[](url)객체가 생성된 이후 시간이 지나고 메세지를 발생할 경우 발생하는 인증 에러를 피하기 위해

메세지 발송시점에 timestamp 값 생성 및 signature를 생성하도록 변경하였습니다.


위의 상황은, 메세지를 대량 발송하면서 한번 생성된 객체를 계속 사용 할 경우, 한번 생성된 timestamp가 나중에는 유효하지 않게 되면서 발생합니다.

[참조: API Gateway 서버와 시간 차가 5분 이상 나는 경우 유효하지 않은 요청으로 간주](https://api.ncloud-docs.com/docs/ai-application-service-sens-alimtalkv2)
